### PR TITLE
Ch 6 Concurrency: Fix missing "time" import.

### DIFF
--- a/en/go.md
+++ b/en/go.md
@@ -1726,6 +1726,7 @@ package main
 
 import (
   "fmt"
+  "time"
   "math/rand"
 )
 


### PR DESCRIPTION
This change imports the "time" package which is missing from the channel/worker example code in Chapter 6 - Concurrency.
