### PR TITLE
Change array size description (again)

### DIFF
--- a/en/go.md
+++ b/en/go.md
@@ -699,7 +699,9 @@ var scores [10]int
 scores[0] = 339
 ```
 
-The above array can hold up to 10 scores. No more (no less!). We can intialize the array with values:
+The above array can hold up to 10 scores using indexes `scores[0]` through `scores[9]`. Attempts to access an out of range index in the array will result in a compiler or runtime error.
+
+We can initialize the array with values:
 
 ```go
 scores := [4]int{9001, 9333, 212, 33}


### PR DESCRIPTION
Hey Karl,

The changes you made in #7 made the "(no less!)" in the following sentence a little confusing:

> The above array can hold up to 10 scores. No more (no less!). We can intialize the array with values:

I removed the "No more (no less!)" sentence all together and explicitly defined the bounds of the array instead. I also added a line break to better separate this thought and the initialization in the next section, as well as corrected the spelling of "initiated":

> The above array can hold up to 10 scores using indexes `scores[0]` through `scores[9]`. Attempts to access an out of range index in the array will result in a compiler or runtime error.
> 
> We can initialize the array with values:

Let me know if you'd like me to split up these PRs or make any additional changes.

Thanks!
