### PR TITLE
Plurality fix; add a comma before however

### DIFF
--- a/en/go.md
+++ b/en/go.md
@@ -1538,7 +1538,7 @@ func process() {
 }
 ```
 
-There are a few interesting things going on here, but the most important is how we start a goroutine. We simply use the `go` keyword followed by the function we want to execute. If we just want to run a bit of code, such as the above, we can use an anonymous function. Do note that anonymous functions aren't only used with goroutine however.
+There are a few interesting things going on here, but the most important is how we start a goroutine. We simply use the `go` keyword followed by the function we want to execute. If we just want to run a bit of code, such as the above, we can use an anonymous function. Do note that anonymous functions aren't only used with goroutines, however.
 
 ```go
 go func() {


### PR DESCRIPTION
> Do note that anonymous functions aren't only used with goroutine however.

"goroutine" should be plural here, and adding a comma before the "however" is probably preferred.

> Do note that anonymous functions aren't only used with goroutines, however.

Thanks again Karl! Great, concise book as always. I've been using Go here-and-there for a few months and this has really helped solidify some otherwise difficult concepts.
