### PR TITLE
Improve formulation on interface type conversion

### DIFF
--- a/en/go.md
+++ b/en/go.md
@@ -1466,11 +1466,13 @@ func add(a interface{}, b interface{}) interface{} {
 }
 ```
 
-To convert a variable to a specific type, you use `.(TYPE)`:
+To convert an interface variable to an explicit type, you use `.(TYPE)`:
 
 ```go
 return a.(int) + b.(int)
 ```
+
+Note that if the underlying type is not `int`, the above will result in an error.
 
 You also have access to a powerful type switch:
 


### PR DESCRIPTION
Since `.(TYPE)` merely extracts the explicit type of the interface, try
to indicate more clearly that this is not a typecast.

This could be written even more detailed, but it seems like a good idea
to avoid going too deep. If reader needs more info, Effective Go[1]
provides a good explanation.

[1] https://golang.org/doc/effective_go.html#interface_conversions