### PR TITLE
Fix double-space in output for fmt.Println

### DIFF
--- a/en/go.md
+++ b/en/go.md
@@ -198,7 +198,7 @@ func main() {
   if len(os.Args) != 2 {
     os.Exit(1)
   }
-  fmt.Println("It's over ", os.Args[1])
+  fmt.Println("It's over", os.Args[1])
 }
 ```
 


### PR DESCRIPTION
fmt.Println automatically adds a space between args, so trailing space produces a double spaced `It's over  9000`