### PR TITLE
Use concurrency example that demonstrates problem

### DIFF
--- a/en/go.md
+++ b/en/go.md
@@ -1610,7 +1610,7 @@ import (
 var counter = 0
 
 func main() {
-  for i := 0; i < 2; i++ {
+  for i := 0; i < 20; i++ {
     go incr()
   }
   time.Sleep(time.Millisecond * 10)
@@ -1624,9 +1624,9 @@ func incr() {
 
 What do you think the output will be?
 
-If you think the output is `1, 2` you're both right and wrong. It's true that if you run the above code, you'll very likely get that output. However, the reality is that the behavior is undefined. Why? Because we potentially have multiple (two in this case) goroutines writing to the same variable, `counter`, at the same time. Or, just as bad, one goroutine would be reading `counter` while another writes to it.
+If you think the output is `1, 2, ... 20` you're both right and wrong. It's true that if you run the above code, you'll sometimes get that output. However, the reality is that the behavior is undefined. Why? Because we potentially have multiple (two in this case) goroutines writing to the same variable, `counter`, at the same time. Or, just as bad, one goroutine would be reading `counter` while another writes to it.
 
-Is that really a danger? Yes, absolutely. `counter++` might seem like a simple line of code, but it actually gets broken down into multiple assembly statements -- the exact nature is dependent on the platform that you're running. It's true that, in this example, the most likely case is things will run just fine. However, another possible outcome would be that they both see `counter` when its equal to `0` and you get an output of `1, 1`. There are worse possibilities, such as system crashes or accessing an arbitrary piece of data and incrementing it!
+Is that really a danger? Yes, absolutely. `counter++` might seem like a simple line of code, but it actually gets broken down into multiple assembly statements -- the exact nature is dependent on the platform that you're running. If you run this example, you'll see that very often the numbers are printed in a weird order, and/or numbers are duplicated/missing. There are worse possibilities too, such as system crashes or accessing an arbitrary piece of data and incrementing it!
 
 The only concurrent thing you can safely do to a variable is to read from it. You can have as many readers as you want, but writes need to be synchronized. There are various ways to do this, including using some truly atomic operations that rely on special CPU instructions. However, the most common approach is to use a mutex:
 


### PR DESCRIPTION
I found that I couldn't get it to produce output other than 1 2 when I ran it.

The code I've changed it to produces erratic output a lot of the time; which I feel better shows the problems of bad concurrency.

Someone less familiar with concurrency could be led to believe that these effects happen rarely enough to be ignored with the current example I feel.