### PR TITLE
Use of 5 for index and value in consecutive examples is confusing

### DIFF
--- a/en/go.md
+++ b/en/go.md
@@ -767,7 +767,7 @@ To better understand the interplay between length and capacity, let's look at so
 ```go
 func main() {
   scores := make([]int, 0, 10)
-  scores[5] = 9033
+  scores[7] = 9033
   fmt.Println(scores)
 }
 ```


### PR DESCRIPTION
If you take a look at the section below through the eyes of a total newcomer to the language, the use of 5 as an index in the first example, and the value to be appended in the second, is confusing.

I subconsciously thought that maybe the append function was pushing a value into index 5 until I read further and ran the example. There's an expectation that one example will show the "wrong way" to do something, and that the following example will show you the "right way" to do the exact same thing.

Better to avoid this potential confusion altogether. I've replaced `scores[5]` with `scores[7]`.

-------

To better understand the interplay between length and capacity, let's look at some examples:

```go
func main() {
  scores := make([]int, 0, 10)
  scores[5] = 9033
  fmt.Println(scores)
}
```

Our first example crashes. Why? Because our slice has a length of 0. Yes, the underlying array has 10 elements, but we need to explicitly expand our slice in order to access those elements. One way to expand a slice is via `append`:

```go
func main() {
  scores := make([]int, 0, 10)
  scores = append(scores, 5)
  fmt.Println(scores) // prints [5]
}
```

