### PR TITLE
Update paragraph in the composition section

### DIFF
--- a/en/go.md
+++ b/en/go.md
@@ -601,7 +601,7 @@ gohan := &Saiyan{
 
 ## Composition
 
-Go supports composition, which is the act of including one structure into another. In some languages, this is called a trait or a mixin. Languages that don't have an explicit composition mechanism can always do it the long way. In Java:
+Go supports composition, which is the act of including one structure into another. In some languages, this is called a trait or a mixin. Languages that don't have an explicit composition mechanism can always do it the long way. In Java, there's the possibility to extend structures with *inheritance* but, in a scenario where this is not an option, a mixin would be written like this:
 
 ```java
 public class Person {


### PR DESCRIPTION
This update helps clarifying why in the Java example inheritance is not used. Not specifying this can be misleading and lead the reader to think that the author doesn't fully know the Java syntax.