### PR TITLE
Fix PDF rendering with Pandoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BOOK_FILE_NAME = go
 
 PDF_BUILDER = pandoc
 PDF_BUILDER_FLAGS = \
-	--latex-engine xelatex \
+	--pdf-engine xelatex \
 	--template ../common/pdf-template.tex \
 	--listings
 

--- a/common/pdf-template.tex
+++ b/common/pdf-template.tex
@@ -90,6 +90,7 @@
   showtabs = false
 }
 
+\newcommand{\passthrough}[1]{#1}
 
 % Links
 


### PR DESCRIPTION
Fixed pandoc error message: `--latex-engine has been removed.  Use --pdf-engine instead.`

Since version 2 point something Pandoc puts verbatim text in a \passthrough command which is defined in the default template used by Pandoc.  I have just copy pasted the definition.