### PR TITLE
Chapter 6 - Concurrency: Fix process method receiver

### DIFF
--- a/en/go.md
+++ b/en/go.md
@@ -1732,7 +1732,7 @@ type Worker struct {
   id int
 }
 
-func (w Worker) process(c chan int) {
+func (w *Worker) process(c chan int) {
   for {
     data := <-c
     fmt.Printf("worker %d got %d\n", w.id, data)


### PR DESCRIPTION
It looks like we need to use *Worker type in the receiver as you did in the code below - line 1792. 
As per your suggestion to choose ref types (to decrease memory consumption) and keep a uniform code style.
I am new in Go, please correct me if I wrong ^___^