### PR TITLE
readme.md: bring links up-to-date

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,12 @@
 ## About ##
-[The Little Go Book](http://openmymind.net/The-Little-Go-Book/) is a free book introducing Go.
+[The Little Go Book](https://www.openmymind.net/The-Little-Go-Book/) is a free book introducing Go.
 
-The book was written by [Karl Seguin](http://openmymind.net), author of:
+The book was written by [Karl Seguin](https://openmymind.net), author of:
 
-* [Scaling Viki](http://openmymind.net/scaling-viki/)
-* [The Little Redis Book](http://openmymind.net/2012/1/23/The-Little-Redis-Book/)
-* [The Little MongoDB Book](http://openmymind.net/2011/3/28/The-Little-MongoDB-Book/)
-* [Foundations of Programming](http://openmymind.net/FoundationsOfProgramming.pdf)
+* [Scaling Viki](https://openmymind.net/scaling-viki/)
+* [The Little Redis Book](https://openmymind.net/2012/1/23/The-Little-Redis-Book/)
+* [The Little MongoDB Book](https://openmymind.net/2011/3/28/The-Little-MongoDB-Book/)
+* [Foundations of Programming](https://openmymind.net/FoundationsOfProgramming.pdf)
 
 ## License ##
 The book is freely distributed under the  [Attribution-NonCommercial-ShareAlike 4.0 International](<http://creativecommons.org/licenses/by-nc-sa/4.0/>).
@@ -27,11 +27,11 @@ The book is freely distributed under the  [Attribution-NonCommercial-ShareAlike 
 * [Turkish](https://github.com/umutphp/the-little-go-book) By Umut Işık
 
 ## Formats ##
-The book is written in [Markdown](http://daringfireball.net/projects/markdown/) and converted to PDF using [Pandoc](http://johnmacfarlane.net/pandoc/).
+The book is written in [Markdown](https://daringfireball.net/projects/markdown/) and converted to PDF using [Pandoc](https://pandoc.org).
 
 The TeX template makes use of Lena Herrmann's JavaScript highlighter.
 
-Kindle and ePub format provided using [Pandoc](http://johnmacfarlane.net/pandoc/).
+Kindle and ePub format provided using [Pandoc](https://pandoc.org).
 
 ## Generating books ##
 Packages listed below are for Ubuntu. If you use another OS or distribution names would be similar.
@@ -74,11 +74,11 @@ Packages:
 
 * `pandoc`
 
-You should have [KindleGen](http://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211) installed too.
+You should have [Kindle Previewer](https://www.amazon.com/Kindle-Previewer/b?node=21381691011) installed too.
 
 #### Building
 
 Run `make en/go.mobi`.
 
 ## Title Image ##
-A PSD of the title image is included. The font used is [Comfortaa](http://www.dafont.com/comfortaa.font).
+A PSD of the title image is included. The font used is [Comfortaa](https://www.dafont.com/comfortaa.font).


### PR DESCRIPTION
This PR updates outdated information on KindleGen. It also changes various links from `http` to `https` protocol.