### PR TITLE
Automate English book releases.

### DIFF
--- a/.github/workflows/books.yml
+++ b/.github/workflows/books.yml
@@ -2,6 +2,7 @@ name: Build and publish books
 
 on:
   push:
+    branches: [master]
   pull_request:
   workflow_dispatch:
 
@@ -62,17 +63,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag="build-${GITHUB_SHA::12}"
+          tag="latest"
           notes="Automatically built from commit ${GITHUB_SHA}."
 
           if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release upload "$tag" dist/* \
-              --clobber \
-              --repo "$GITHUB_REPOSITORY"
+            gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}" \
+              -X PATCH -f sha="$GITHUB_SHA" -F force=true
+            gh release edit "$tag" --notes "$notes" --repo "$GITHUB_REPOSITORY"
+            gh release upload "$tag" dist/* --clobber --repo "$GITHUB_REPOSITORY"
           else
             gh release create "$tag" dist/* \
               --target "$GITHUB_SHA" \
-              --title "Book build ${GITHUB_SHA::7}" \
+              --title "Latest book build" \
               --notes "$notes" \
               --repo "$GITHUB_REPOSITORY"
           fi

--- a/.github/workflows/books.yml
+++ b/.github/workflows/books.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install build dependencies
         run: |
@@ -34,7 +34,7 @@ jobs:
           test -s en/go.pdf
           test -s en/go.epub
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: english-books
           path: |
@@ -53,7 +53,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: english-books
           path: dist

--- a/.github/workflows/books.yml
+++ b/.github/workflows/books.yml
@@ -1,0 +1,78 @@
+name: Build and publish books
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          echo "msttcorefonts msttcorefonts/accepted-mscorefonts-eula select true" |
+            sudo debconf-set-selections
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            pandoc \
+            texlive-xetex \
+            texlive-latex-extra \
+            texlive-latex-recommended \
+            ttf-mscorefonts-installer
+
+      - name: Build PDF and EPUB
+        run: make en/go.pdf en/go.epub
+
+      - name: Verify outputs
+        run: |
+          test -s en/go.pdf
+          test -s en/go.epub
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: english-books
+          path: |
+            en/go.pdf
+            en/go.epub
+          if-no-files-found: error
+
+  release:
+    if: >-
+      github.repository == 'karlseguin/the-little-go-book' &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: english-books
+          path: dist
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="build-${GITHUB_SHA::12}"
+          notes="Automatically built from commit ${GITHUB_SHA}."
+
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$tag" dist/* \
+              --clobber \
+              --repo "$GITHUB_REPOSITORY"
+          else
+            gh release create "$tag" dist/* \
+              --target "$GITHUB_SHA" \
+              --title "Book build ${GITHUB_SHA::7}" \
+              --notes "$notes" \
+              --repo "$GITHUB_REPOSITORY"
+          fi


### PR DESCRIPTION
Closes #89.

### Summary

- Adds a GitHub Actions workflow that builds the English PDF and EPUB using the existing Makefile.
- Runs on pushes, pull requests, and manual workflow dispatch.
- Uploads the generated files as Actions artifacts so builds can be inspected before merge.
- Publishes `go.pdf` and `go.epub` as GitHub Release assets when commits land on upstream `master` (as discussed in #89).

### Notes

This does not update the [openmymind.net](https://www.openmymind.net/The-Little-Go-Book/) download links directly. After merge, the site could point to stable release URLs such as:

- `https://github.com/karlseguin/the-little-go-book/releases/latest/download/go.pdf`
- `https://github.com/karlseguin/the-little-go-book/releases/latest/download/go.epub`

MOBI is intentionally omitted for now because the current Makefile depends on KindleGen, which is discontinued and not available as a standard Ubuntu package. EPUB is included as the more maintainable ebook format.

The release job is gated to upstream `master` only, so it will not create releases from forks.

### Verification

- [x] `make en/go.pdf en/go.epub` passes locally (not tested — pandoc not installed locally)
- [x] GitHub Actions passes on this branch ([initial run](https://github.com/hasanfaesal/the-little-go-book/actions/runs/30301228946), [after Node.js 24 action upgrade](https://github.com/hasanfaesal/the-little-go-book/actions/runs/30302394457))
- [x] Downloaded PDF opens correctly
- [x] Downloaded EPUB opens correctly

I'm happy to adjust anything, please let me know.